### PR TITLE
Bench: state add more trasitions

### DIFF
--- a/bench/highState.zig
+++ b/bench/highState.zig
@@ -15,12 +15,17 @@ pub fn Example(Current: type) type {
 
 pub fn Dummy(comptime Next: type, comptime int: comptime_int) type {
     return union(enum) {
-        to_next: Example(Next),
+        to_next0: Example(Next),
+        to_next1: Example(Next),
+        to_next2: Example(Next),
+        to_next3: Example(Next),
+        to_next4: Example(Next),
+        to_next5: Example(Next),
 
         pub const int_decl = int;
 
         pub fn handler(_: *Context) @This() {
-            return .to_next;
+            return .to_next0;
         }
     };
 }

--- a/src/polystate.zig
+++ b/src/polystate.zig
@@ -41,7 +41,7 @@ pub const StateMap = struct {
     StateId: type,
 
     pub fn init(comptime FsmState: type) StateMap {
-        @setEvalBranchQuota(20_000_000);
+        @setEvalBranchQuota(200_000_000);
 
         comptime {
             const states = reachableStates(FsmState);


### PR DESCRIPTION
```shell
➜  polystate git:(state-more-trasition) ✗ time zig build bench
zig build bench  51.31s user 1.53s system 103% cpu 51.129 total
```
Peak memory 2G

Adding 5 additional state transitions to each state increases the compilation time from 45s to 51s, about 13%.

More state migrations seem to have less impact on compile time.
